### PR TITLE
Fix: AWS Authentication Error

### DIFF
--- a/src/main/api/bedrock/client.ts
+++ b/src/main/api/bedrock/client.ts
@@ -4,13 +4,25 @@ import { BedrockAgentRuntimeClient } from '@aws-sdk/client-bedrock-agent-runtime
 import type { AWSCredentials } from './types'
 
 export function createRuntimeClient(awsCredentials: AWSCredentials) {
-  return new BedrockRuntimeClient(awsCredentials)
+  const { region, ...credentials } = awsCredentials
+  return new BedrockRuntimeClient({
+    region,
+    credentials
+  })
 }
 
 export function createBedrockClient(awsCredentials: AWSCredentials) {
-  return new BedrockClient(awsCredentials)
+  const { region, ...credentials } = awsCredentials
+  return new BedrockClient({
+    region,
+    credentials
+  })
 }
 
 export function createAgentRuntimeClient(awsCredentials: AWSCredentials) {
-  return new BedrockAgentRuntimeClient(awsCredentials)
+  const { region, ...credentials } = awsCredentials
+  return new BedrockAgentRuntimeClient({
+    region,
+    credentials
+  })
 }


### PR DESCRIPTION
issue #29 

*Description of changes:*

AWSの認証情報オブジェクトの型が期待するものと一致せずにエラーが発生しています。
SDKが想定する設定形式に合わせて、リージョンと認証情報のパラメータに分割します。この変更は、すべてのBedrockクライアントのインスタンス化に影響します。

---

An error is occurring because the AWS credentials object type does not match what is expected.
Split AWS credentials object into region and credentials parameters to match SDK's expected configuration format. This change affects all Bedrock client instantiations.