### PR TITLE
DeepSeek R1 support

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -16,7 +16,7 @@ Bedrock Engineer はネイティブアプリです。アプリをダウンロー
 
 MacOS:
 
-[<img src="https://img.shields.io/badge/Download_FOR_MAC-Latest%20Release-blue?style=for-the-badge&logo=apple" alt="Download Latest Release" height="40">](https://github.com/aws-samples/bedrock-engineer/releases/latest/download/bedrock-engineer-1.3.1.dmg)
+[<img src="https://img.shields.io/badge/Download_FOR_MAC-Latest%20Release-blue?style=for-the-badge&logo=apple" alt="Download Latest Release" height="40">](https://github.com/aws-samples/bedrock-engineer/releases/latest/download/bedrock-engineer-1.3.2.dmg)
 
 <details>
 <summary>Tips for Installation</summary>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Bedrock Engineer is a native app, you can download the app or build the source c
 
 MacOS:
 
-[<img src="https://img.shields.io/badge/Download_FOR_MAC-Latest%20Release-blue?style=for-the-badge&logo=apple" alt="Download Latest Release" height="40">](https://github.com/aws-samples/bedrock-engineer/releases/latest/download/bedrock-engineer-1.3.1.dmg)
+[<img src="https://img.shields.io/badge/Download_FOR_MAC-Latest%20Release-blue?style=for-the-badge&logo=apple" alt="Download Latest Release" height="40">](https://github.com/aws-samples/bedrock-engineer/releases/latest/download/bedrock-engineer-1.3.2.dmg)
 
 <details>
 <summary>Tips for Installation</summary>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bedrock-engineer",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Autonomous software development agent apps using Amazon Bedrock, capable of customize to create/edit files, execute commands, search the web, use knowledge base, use multi-agents, generative images and more.",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/daisuke-awaji/bedrock-engineer",

--- a/src/main/api/bedrock/models.ts
+++ b/src/main/api/bedrock/models.ts
@@ -136,7 +136,7 @@ export const usModels: LLM[] = [
     modelId: 'us.deepseek.r1-v1:0',
     modelName: 'DeepSeek R1 (US cross-region)',
     toolUse: false,
-    regions: ['us-west-2']
+    regions: usRegions
   }
 ]
 

--- a/src/main/api/bedrock/models.ts
+++ b/src/main/api/bedrock/models.ts
@@ -130,6 +130,13 @@ export const usModels: LLM[] = [
     modelName: 'Amazon Nova Micro (US cross-region)',
     toolUse: true,
     regions: usRegions
+  },
+  // DeepSeek
+  {
+    modelId: 'us.deepseek.r1-v1:0',
+    modelName: 'DeepSeek R1 (US cross-region)',
+    toolUse: false,
+    regions: ['us-west-2']
   }
 ]
 

--- a/src/main/api/bedrock/services/modelService.ts
+++ b/src/main/api/bedrock/services/modelService.ts
@@ -4,7 +4,7 @@ import type { ServiceContext } from '../types'
 import { BedrockSupportRegion } from '../../../../types/llm'
 
 export class ModelService {
-  private static readonly CACHE_LIFETIME = 1000 * 60 * 60 // 1 hour
+  private static readonly CACHE_LIFETIME = 1000 * 60 * 5 // 5 min
   private modelCache: { [key: string]: any } = {}
 
   constructor(private context: ServiceContext) {}


### PR DESCRIPTION
# Add DeepSeek R1 model support

This PR adds support for the DeepSeek R1 model.

## Changes
- Added DeepSeek R1 (US cross-region) configuration to `src/main/api/bedrock/models.ts`
- Model ID: 'us.deepseek.r1-v1:0'
- Region: 'us-east-1', 'us-east-2', 'us-west-2'

## Testing
- [x] Verify the model loads correctly
- [x] Confirm API calls work as expected

## Additional Information
- DeepSeek R1 is a new LLM model available on Amazon Bedrock
https://aws.amazon.com/jp/blogs/aws/deepseek-r1-now-available-as-a-fully-managed-serverless-model-in-amazon-bedrock/