### PR TITLE
Automatically set max tokens when switching models

### DIFF
--- a/src/main/api/bedrock/models.ts
+++ b/src/main/api/bedrock/models.ts
@@ -6,6 +6,7 @@ export const baseModels: LLM[] = [
     modelId: 'anthropic.claude-3-sonnet-20240229-v1:0',
     modelName: 'Claude 3 Sonnet',
     toolUse: true,
+    maxTokensLimit: 8192,
     regions: [
       'us-east-1',
       'us-east-2',
@@ -24,6 +25,7 @@ export const baseModels: LLM[] = [
     modelId: 'anthropic.claude-3-haiku-20240307-v1:0',
     modelName: 'Claude 3 Haiku',
     toolUse: true,
+    maxTokensLimit: 4096,
     regions: [
       'us-east-1',
       // 'us-east-2',
@@ -42,6 +44,7 @@ export const baseModels: LLM[] = [
     modelId: 'anthropic.claude-3-5-haiku-20241022-v1:0',
     modelName: 'Claude 3.5 Haiku',
     toolUse: true,
+    maxTokensLimit: 8192,
     regions: [
       // 'us-east-1',
       // 'us-east-2',
@@ -52,6 +55,7 @@ export const baseModels: LLM[] = [
     modelId: 'anthropic.claude-3-5-sonnet-20240620-v1:0',
     modelName: 'Claude 3.5 Sonnet',
     toolUse: true,
+    maxTokensLimit: 8192,
     regions: [
       'us-east-1',
       // 'us-east-2',
@@ -70,6 +74,7 @@ export const baseModels: LLM[] = [
     modelId: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
     modelName: 'Claude 3.5 Sonnet v2',
     toolUse: true,
+    maxTokensLimit: 8192,
     regions: ['us-west-2']
   }
 ]
@@ -81,54 +86,63 @@ export const usModels: LLM[] = [
     modelId: 'us.anthropic.claude-3-sonnet-20240229-v1:0',
     modelName: 'Claude 3 Sonnet (US cross-region)',
     toolUse: true,
+    maxTokensLimit: 8192,
     regions: ['us-east-1', 'us-west-2']
   },
   {
     modelId: 'us.anthropic.claude-3-haiku-20240307-v1:0',
     modelName: 'Claude 3 Haiku (US cross-region)',
     toolUse: true,
+    maxTokensLimit: 8192,
     regions: usRegions
   },
   {
     modelId: 'us.anthropic.claude-3-5-haiku-20241022-v1:0',
     modelName: 'Claude 3.5 Haiku (US cross-region)',
     toolUse: true,
+    maxTokensLimit: 8192,
     regions: usRegions
   },
   {
     modelId: 'us.anthropic.claude-3-5-sonnet-20240620-v1:0',
     modelName: 'Claude 3.5 Sonnet (US cross-region)',
     toolUse: true,
+    maxTokensLimit: 8192,
     regions: usRegions
   },
   {
     modelId: 'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
     modelName: 'Claude 3.5 Sonnet v2 (US cross-region)',
     toolUse: true,
+    maxTokensLimit: 8192,
     regions: usRegions
   },
   {
     modelId: 'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
     modelName: 'Claude 3.7 Sonnet (US cross-region)',
     toolUse: true,
+    maxTokensLimit: 64000,
     regions: usRegions
   },
   {
     modelId: 'us.amazon.nova-pro-v1:0',
     modelName: 'Amazon Nova Pro (US cross-region)',
     toolUse: true,
+    maxTokensLimit: 5120,
     regions: usRegions
   },
   {
     modelId: 'us.amazon.nova-lite-v1:0',
     modelName: 'Amazon Nova Lite (US cross-region)',
     toolUse: true,
+    maxTokensLimit: 5120,
     regions: usRegions
   },
   {
     modelId: 'us.amazon.nova-micro-v1:0',
     modelName: 'Amazon Nova Micro (US cross-region)',
     toolUse: true,
+    maxTokensLimit: 5120,
     regions: usRegions
   },
   // DeepSeek
@@ -136,6 +150,7 @@ export const usModels: LLM[] = [
     modelId: 'us.deepseek.r1-v1:0',
     modelName: 'DeepSeek R1 (US cross-region)',
     toolUse: false,
+    maxTokensLimit: 32768,
     regions: usRegions
   }
 ]
@@ -148,18 +163,21 @@ export const euModels: LLM[] = [
     modelId: 'eu.anthropic.claude-3-sonnet-20240229-v1:0',
     modelName: 'Claude 3 Sonnet (EU cross-region)',
     toolUse: true,
+    maxTokensLimit: 8192,
     regions: euRegions
   },
   {
     modelId: 'eu.anthropic.claude-3-5-sonnet-20240620-v1:0',
     modelName: 'Claude 3.5 Sonnet (EU cross-region)',
     toolUse: true,
+    maxTokensLimit: 8192,
     regions: euRegions
   },
   {
     modelId: 'eu.anthropic.claude-3-haiku-20240307-v1:0',
     modelName: 'Claude 3 Haiku (EU cross-region)',
     toolUse: true,
+    maxTokensLimit: 4096,
     regions: euRegions
   }
 ]
@@ -179,18 +197,21 @@ export const apacModels: LLM[] = [
     modelId: 'apac.anthropic.claude-3-5-sonnet-20241022-v2:0',
     modelName: 'Claude 3.5 Sonnet v2 (APAC cross-region)',
     toolUse: true,
+    maxTokensLimit: 8192,
     regions: apacRegions
   },
   {
     modelId: 'apac.anthropic.claude-3-sonnet-20240229-v1:0',
     modelName: 'Claude 3 Sonnet (APAC cross-region)',
     toolUse: true,
+    maxTokensLimit: 8192,
     regions: ['ap-northeast-1']
   },
   {
     modelId: 'apac.anthropic.claude-3-haiku-20240307-v1:0',
     modelName: 'Claude 3 Haiku (APAC cross-region)',
     toolUse: true,
+    maxTokensLimit: 4096,
     regions: ['ap-northeast-1']
   }
 ]
@@ -226,11 +247,13 @@ export const getDefaultPromptRouter = (accountId: string, region: string) => {
       {
         modelId: `arn:aws:bedrock:${region}:${accountId}:default-prompt-router/anthropic.claude:1`,
         modelName: 'Claude Prompt Router',
+        maxTokensLimit: 8192,
         toolUse: true
       },
       {
         modelId: `arn:aws:bedrock:${region}:${accountId}:default-prompt-router/meta.llama:1`,
         modelName: 'Meta Prompt Router',
+        maxTokensLimit: 8192,
         toolUse: false
       }
     ]

--- a/src/renderer/src/contexts/SettingsContext.tsx
+++ b/src/renderer/src/contexts/SettingsContext.tsx
@@ -445,16 +445,25 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   }
 
   useEffect(() => {
-    if (currentLLM && currentLLM.toolUse === false) {
-      // currentLLM が ToolUse をサポートしないモデルだった場合ツールを全て disabled にする
-      const updatedTools = window.tools.map((tool) => ({ ...tool, enabled: false }))
-      setStateTools(updatedTools)
-      window.store.set('tools', updatedTools)
-    }
-    if (currentLLM && currentLLM.toolUse === true) {
-      const updatedTools = window.tools.map((tool) => ({ ...tool, enabled: true }))
-      setStateTools(updatedTools)
-      window.store.set('tools', updatedTools)
+    if (currentLLM) {
+      // Update tools based on toolUse support
+      if (currentLLM.toolUse === false) {
+        // currentLLM が ToolUse をサポートしないモデルだった場合ツールを全て disabled にする
+        const updatedTools = window.tools.map((tool) => ({ ...tool, enabled: false }))
+        setStateTools(updatedTools)
+        window.store.set('tools', updatedTools)
+      } else if (currentLLM.toolUse === true) {
+        const updatedTools = window.tools.map((tool) => ({ ...tool, enabled: true }))
+        setStateTools(updatedTools)
+        window.store.set('tools', updatedTools)
+      }
+
+      // Update maxTokens based on model's maxTokensLimit
+      if (currentLLM.maxTokensLimit) {
+        const updatedParams = { ...inferenceParams, maxTokens: currentLLM.maxTokensLimit }
+        setInferenceParams(updatedParams)
+        window.store.set('inferenceParams', updatedParams)
+      }
     }
   }, [currentLLM])
 


### PR DESCRIPTION
## Description
This Pull Request implements automatic token limit adjustment when switching between AI models. This feature enhances user experience by automatically setting the appropriate maximum token count based on the selected model's capabilities.

## Key Changes
- Automatic Token Limit Adjustment
  - Dynamically sets the maximum token count when switching between AI models
  - Ensures optimal token limits based on each model's specifications
  - Prevents token limit errors when using different models
- User Experience Improvements
  - Eliminates the need for manual token adjustment when changing models
  - Provides seamless model switching experience
  - Maintains appropriate context window for each model type
- Technical Implementation
  - Added model-specific token limit configurations
  - Implemented token limit update logic during model selection
  - Ensured compatibility with all supported AI models