### PR TITLE
カスタムエージェント新規登録に初期状態のツールが設定できない問題を修正

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,9 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "CodeGPT.apiKey": "CodeGPT Plus Beta",
-  "CodeGPT.Autocomplete.enabled": true
+  "CodeGPT.Autocomplete.enabled": true,
+  "i18n-ally.localesPaths": [
+    "src/renderer/src/i18n",
+    "src/renderer/src/i18n/locales"
+  ]
 }

--- a/README-ja.md
+++ b/README-ja.md
@@ -19,7 +19,7 @@ Bedrock Engineer はネイティブアプリです。アプリをダウンロー
 
 MacOS:
 
-[<img src="https://img.shields.io/badge/Download_FOR_MAC-Latest%20Release-blue?style=for-the-badge&logo=apple" alt="Download Latest Release" height="40">](https://github.com/aws-samples/bedrock-engineer/releases/latest/download/bedrock-engineer-1.7.0.dmg)
+[<img src="https://img.shields.io/badge/Download_FOR_MAC-Latest%20Release-blue?style=for-the-badge&logo=apple" alt="Download Latest Release" height="40">](https://github.com/aws-samples/bedrock-engineer/releases/latest/download/bedrock-engineer-1.7.1.dmg)
 
 MacOS に最適化されていますが、Windows, Linux OS でもビルドして使用できます。不具合があるばあい、issue に起票ください。
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Bedrock Engineer is a native app, you can download the app or build the source c
 
 MacOS:
 
-[<img src="https://img.shields.io/badge/Download_FOR_MAC-Latest%20Release-blue?style=for-the-badge&logo=apple" alt="Download Latest Release" height="40">](https://github.com/aws-samples/bedrock-engineer/releases/latest/download/bedrock-engineer-1.7.0.dmg)
+[<img src="https://img.shields.io/badge/Download_FOR_MAC-Latest%20Release-blue?style=for-the-badge&logo=apple" alt="Download Latest Release" height="40">](https://github.com/aws-samples/bedrock-engineer/releases/latest/download/bedrock-engineer-1.7.1.dmg)
 
 It is optimized for MacOS, but can also be built and used on Windows and Linux OS. If you have any problems, please report an issue.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bedrock-engineer",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Autonomous software development agent apps using Amazon Bedrock, capable of customize to create/edit files, execute commands, search the web, use knowledge base, use multi-agents, generative images and more.",
   "main": "./out/main/index.js",
   "homepage": "https://github.com/daisuke-awaji/bedrock-engineer",

--- a/src/renderer/src/constants/defaultToolSets.ts
+++ b/src/renderer/src/constants/defaultToolSets.ts
@@ -152,7 +152,7 @@ export const getToolsForCategory = (category: string, allTools: ToolState[]): To
   const currentRegion = awsConfig?.region || ''
 
   // カテゴリに基づいてツール設定を生成
-  return allTools.map((tool) => {
+  const result = allTools.map((tool) => {
     const toolName = tool.toolSpec?.name
     if (!toolName) return { ...tool, enabled: false }
 
@@ -167,9 +167,14 @@ export const getToolsForCategory = (category: string, allTools: ToolState[]): To
       }
     }
 
+    // このツールがカテゴリに含まれるかどうか
+    const isEnabled = categoryNames.includes(toolName)
+
     return {
       ...tool,
-      enabled: categoryNames.includes(toolName)
+      enabled: isEnabled
     }
   })
+
+  return result
 }


### PR DESCRIPTION
カスタムエージェント新規登録に初期状態のツールがすべてONになっているにも関わらず OFFとして登録されてしまう問題を修正しました。


<img width="1912" alt="スクリーンショット 2025-04-03 13 17 59" src="https://github.com/user-attachments/assets/a9e1b23f-2792-49f3-98e2-682a0600df0a" />
