### PR TITLE
Electron apps as GUI apps on macOS and Linux do not inherit the $PATH…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "electron-store": "8.2.0",
         "electron-updater": "^6.3.9",
         "express": "^4.21.2",
+        "fix-path": "^4.0.0",
         "flowbite-react": "0.10.1",
         "framer-motion": "11.3.29",
         "i18next": "23.15.0",
@@ -17720,6 +17721,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/default-shell": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/default-shell/-/default-shell-2.2.0.tgz",
+      "integrity": "sha512-sPpMZcVhRQ0nEMDtuMJ+RtCxt7iHPAMBU+I4tAlo5dU1sjRpNax0crj6nR3qKpvVnckaQ9U38enXcwW9nZJeCw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
@@ -19258,7 +19271,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -19282,7 +19294,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -19670,6 +19681,21 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/fix-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fix-path/-/fix-path-4.0.0.tgz",
+      "integrity": "sha512-g31GX207Tt+psI53ZSaB1egprYbEN0ZYl90aKcO22A2LmCNnFsSq3b5YpoKp3E/QEiWByTXGJOkFQG4S07Bc1A==",
+      "license": "MIT",
+      "dependencies": {
+        "shell-path": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -20683,7 +20709,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
@@ -23088,7 +23113,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
@@ -24025,7 +24049,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -26355,6 +26378,65 @@
         "node": ">=8"
       }
     },
+    "node_modules/shell-env": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/shell-env/-/shell-env-4.0.1.tgz",
+      "integrity": "sha512-w3oeZ9qg/P6Lu6qqwavvMnB/bwfsz67gPB3WXmLd/n6zuh7TWQZtGa3iMEdmua0kj8rivkwl+vUjgLWlqZOMPw==",
+      "license": "MIT",
+      "dependencies": {
+        "default-shell": "^2.0.0",
+        "execa": "^5.1.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/shell-env/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/shell-env/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/shell-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shell-path/-/shell-path-3.0.0.tgz",
+      "integrity": "sha512-HNIZ+W/3P0JuVTV03xjGqYKt3e3h0/Z4AH8TQWeth1LBtCusSjICgkdNdb3VZr6mI7ijE2AiFFpgkVMNKsALeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "shell-env": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -26431,7 +26513,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/simple-swizzle": {
@@ -26827,7 +26908,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "electron-store": "8.2.0",
     "electron-updater": "^6.3.9",
     "express": "^4.21.2",
+    "fix-path": "^4.0.0",
     "flowbite-react": "0.10.1",
     "framer-motion": "11.3.29",
     "i18next": "23.15.0",

--- a/src/main/api/bedrock/client.ts
+++ b/src/main/api/bedrock/client.ts
@@ -2,31 +2,50 @@ import { BedrockRuntimeClient } from '@aws-sdk/client-bedrock-runtime'
 import { BedrockClient } from '@aws-sdk/client-bedrock'
 import { BedrockAgentRuntimeClient } from '@aws-sdk/client-bedrock-agent-runtime'
 import type { AWSCredentials } from './types'
-import { fromIni } from '@aws-sdk/credential-providers'
 
 export function createRuntimeClient(awsCredentials: AWSCredentials) {
   const { region, useProfile, profile, ...credentials } = awsCredentials
+  if (useProfile) {
+    return new BedrockRuntimeClient({
+      region,
+      profile
+    })
+  }
 
   return new BedrockRuntimeClient({
     region,
-    credentials: useProfile && profile ? fromIni({ profile }) : credentials
+    credentials
   })
 }
 
 export function createBedrockClient(awsCredentials: AWSCredentials) {
   const { region, useProfile, profile, ...credentials } = awsCredentials
 
+  if (useProfile) {
+    return new BedrockClient({
+      region,
+      profile
+    })
+  }
+
   return new BedrockClient({
     region,
-    credentials: useProfile && profile ? fromIni({ profile }) : credentials
+    credentials
   })
 }
 
 export function createAgentRuntimeClient(awsCredentials: AWSCredentials) {
   const { region, useProfile, profile, ...credentials } = awsCredentials
 
+  if (useProfile) {
+    return new BedrockAgentRuntimeClient({
+      region,
+      profile
+    })
+  }
+
   return new BedrockAgentRuntimeClient({
     region,
-    credentials: useProfile && profile ? fromIni({ profile }) : credentials
+    credentials
   })
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,7 +17,14 @@ import {
   createCategoryLogger
 } from '../common/logger'
 import { handleFileOpen } from '../preload/file'
-
+// 動的インポートを使用してfix-pathパッケージを読み込む
+import('fix-path')
+  .then((fixPathModule) => {
+    fixPathModule.default()
+  })
+  .catch((err) => {
+    console.error('Failed to load fix-path module:', err)
+  })
 // No need to track project path anymore as we always read from disk
 Store.initRenderer()
 

--- a/src/renderer/src/i18n/locales/settings/bedrock/index.ts
+++ b/src/renderer/src/i18n/locales/settings/bedrock/index.ts
@@ -2,7 +2,7 @@ export const bedrockSettings = {
   en: {
     // AWS Profile Settings
     'Use AWS Profile': 'Use AWS Profile',
-    'Use credentials from ~/.aws/credentials': 'Use credentials from ~/.aws/credentials',
+    'Use credentials from ~/.aws': 'Use credentials from ~/.aws',
     'AWS Profile Name': 'AWS Profile Name',
     // Bedrock Settings
     'Enable Region Failover on ThrottlingException':
@@ -28,7 +28,7 @@ export const bedrockSettings = {
   ja: {
     // AWS Profile Settings
     'Use AWS Profile': 'AWS プロファイルを使用する',
-    'Use credentials from ~/.aws/credentials': '~/.aws/credentials から認証情報を使用します',
+    'Use credentials from ~/.aws': '~/.aws から認証情報を使用します',
     'AWS Profile Name': 'AWS プロファイル名',
     // Bedrock Settings
     'Enable Region Failover on ThrottlingException':

--- a/src/renderer/src/pages/SettingPage/components/sections/AWSSection.tsx
+++ b/src/renderer/src/pages/SettingPage/components/sections/AWSSection.tsx
@@ -163,7 +163,7 @@ export const AWSSection: React.FC<AWSSectionProps> = ({
             {useAwsProfile ? (
               <div className="space-y-4 p-4 border border-gray-200 dark:border-gray-700 rounded-md">
                 <p className="text-xs text-gray-600 dark:text-gray-400">
-                  {t('Use credentials from ~/.aws/credentials')}
+                  {t('Use credentials from ~/.aws')}
                 </p>
 
                 <SettingInput


### PR DESCRIPTION
… defined in your dotfiles (.bashrc/.bash_profile/.zshrc/etc).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
