### PR TITLE
Improve prompt caching for Amazon Nova

### DIFF
--- a/src/renderer/src/pages/ChatPage/components/AgentForm/McpServerSection/McpServerForm.tsx
+++ b/src/renderer/src/pages/ChatPage/components/AgentForm/McpServerSection/McpServerForm.tsx
@@ -149,7 +149,7 @@ export const McpServerForm: React.FC<McpServerFormProps> = ({
       className="flex flex-col gap-2 mt-4 border border-gray-200 dark:border-gray-700 p-4 rounded-md"
       onClick={preventModalClose}
     >
-      <h4 className="font-medium text-sm mb-2">
+      <h4 className="font-medium text-sm mb-2 dark:text-gray-300">
         {editMode ? t('Edit MCP Server') : t('Add New MCP Server')}
       </h4>
 
@@ -181,7 +181,7 @@ export const McpServerForm: React.FC<McpServerFormProps> = ({
             if (jsonError) setJsonError(null)
           }}
           onClick={preventModalClose}
-          className="mt-1 block w-full h-64 px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm font-mono"
+          className="mt-1 block w-full h-64 px-3 py-2 bg-white dark:bg-gray-800 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm font-mono"
           placeholder={`{
   "mcpServers": {
     "my-mcp-server": {

--- a/src/renderer/src/pages/ChatPage/components/AgentForm/components/FormActionButtons.tsx
+++ b/src/renderer/src/pages/ChatPage/components/AgentForm/components/FormActionButtons.tsx
@@ -15,7 +15,7 @@ export const FormActionButtons: React.FC<{
 
   return (
     <div
-      className="flex justify-end pt-4 pb-4 space-x-2 border-t border-gray-200 dark:border-gray-700 mt-6 sticky bottom-0 bg-white dark:bg-gray-900"
+      className="flex justify-end pt-4 pb-4 space-x-2 border-t border-gray-200 dark:border-gray-600 mt-6 sticky bottom-0 bg-white dark:bg-gray-700"
       onClick={formEventUtils.preventPropagation}
     >
       <button


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Aamzon Nova のプロンプトキャッシュのロジックを修正
  - before: `toolUse が含まれる場合は messages 配列に cachePoint は置かない`
  - after:  `toolResult が含まれてたとしても、その直後以外には cachePoint を置いても ok にする`
- cache point の保持ロジックを修正

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
