### PR TITLE
Adjust maxTokens limit for Claude 3.7 Sonnet model to 32768  for Claude 3.7 Sonnet and 4096 for other models

### DIFF
--- a/src/renderer/src/pages/ChatPage/utils/titleGenerator.ts
+++ b/src/renderer/src/pages/ChatPage/utils/titleGenerator.ts
@@ -41,7 +41,8 @@ export async function generateSessionTitle(
       modelId: modelId ?? 'anthropic.claude-3-haiku-20240307-v1:0',
       system,
       inferenceConfig: {
-        maxTokens: 4096,
+        // Claude 3.7 Sonnetの場合、thinking.budget_tokensより大きい値を設定
+        maxTokens: modelId?.includes('claude-3-7-sonnet') ? 32768 : 4096,
         temperature: 0.5
       },
       messages: [


### PR DESCRIPTION
## Overview

This PR implements model-specific token limits for the session title generator, setting 32768 tokens for Claude 3.7 Sonnet model while maintaining 4096 tokens for other models.

## Problem

The current uniform token limit may not be optimal for all models. Claude 3.7 Sonnet can handle larger context windows effectively, while other models perform best with more constrained token limits. The "Failed to generate title" errors may be occurring due to non-optimized token limits for different model capabilities.

## Solution

By implementing model-specific token limits (32768 tokens for Claude 3.7 Sonnet and 4096 for other models), we optimize resource usage while ensuring each model operates within its ideal parameters. This approach provides ample context for Claude 3.7 Sonnet's advanced capabilities while preventing potential issues with other models by using a more appropriate token limit.

FYI: `src/types/llm.ts:25`

<img width="256" alt="image" src="https://github.com/user-attachments/assets/90194a52-a995-434e-94a9-0c6bdf36c7cf" />