### PR TITLE
Fix: Agent tool settings reset on ChatPage reload

### DIFF
--- a/src/renderer/src/contexts/SettingsContext.tsx
+++ b/src/renderer/src/contexts/SettingsContext.tsx
@@ -16,7 +16,6 @@ import type { AwsCredentialIdentity } from '@smithy/types'
 import { BedrockAgent } from '@/types/agent'
 import { AgentCategory } from '@/types/agent-chat'
 import { getToolsForCategory } from '../constants/defaultToolSets'
-import isEqual from 'lodash/isEqual'
 import { Tool } from '@aws-sdk/client-bedrock-runtime'
 import { CodeInterpreterContainerConfig } from 'src/preload/tools/handlers/interpreter/types'
 import { getEnvironmentContext } from '@renderer/pages/ChatPage/constants/AGENTS_ENVIRONMENT_CONTEXT'
@@ -469,7 +468,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
       const existingAgent = savedAgents.find((agent) => agent.id === defaultAgent.id)
       processedIds.add(defaultAgent.id)
 
-      // プロパティが完全に一致するかチェック
+      // プロパティが完全に一致するかチェック（ツール設定は除外してユーザーのカスタマイズを保持）
       const isIdentical =
         existingAgent &&
         // 基本情報の比較
@@ -478,13 +477,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         existingAgent.system === defaultAgent.system &&
         existingAgent.icon === defaultAgent.icon &&
         existingAgent.iconColor === defaultAgent.iconColor &&
-        existingAgent.category === defaultAgent.category &&
-        // 配列の比較（lodashのisEqualを使用）
-        isEqual(existingAgent.scenarios, defaultAgent.scenarios) &&
-        isEqual(existingAgent.tools, defaultAgent.tools) &&
-        isEqual(existingAgent.allowedCommands, defaultAgent.allowedCommands) &&
-        isEqual(existingAgent.bedrockAgents, defaultAgent.bedrockAgents) &&
-        isEqual(existingAgent.knowledgeBases, defaultAgent.knowledgeBases)
+        existingAgent.category === defaultAgent.category
 
       if (existingAgent && !isIdentical) {
         // IDが一致するが内容が異なる場合は、デフォルトエージェントの内容で更新


### PR DESCRIPTION
不具合内容:
ChatPageを再読み込みした際に、ユーザーがカスタマイズしたエージェントのツール設定がデフォルト値にリセットされてしまう問題がありました。

修正内容:

エージェント比較ロジックを変更し、ツール関連の設定（tools, scenarios, allowedCommands, bedrockAgents, knowledgeBases）を比較対象から除外しました
これにより、基本的なエージェント情報（名前、説明、アイコンなど）のみが比較され、ユーザーがカスタマイズしたツール設定が保持されるようになりました
不要になった lodash の isEqual 関数のインポートを削除しました
影響範囲:

ChatPage でのエージェント設定の永続化に関する動作が変更されます
ユーザーは再読み込み後もツール設定のカスタマイズが維持されることを期待できます


Issue:
When reloading the ChatPage, agent tool settings customized by users were being reset to default values.

Fix:

Modified the agent comparison logic to exclude tool-related properties (tools, scenarios, allowedCommands, bedrockAgents, knowledgeBases) from comparison
Now only basic agent information (name, description, icon, etc.) is compared, allowing user customizations of tool settings to persist
Removed unused import of isEqual function from lodash
Impact:

Changes the persistence behavior of agent settings in the ChatPage
Users can now expect their tool customizations to be maintained after page reload
Testing:

Verified that custom tool configurations persist across page reloads
Confirmed that other agent properties continue to update correctly when defaults change
