### PR TITLE
fix: ドラフトリリースワークフローを確実に起動するよう改善

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -5,6 +5,14 @@ on:
   push:
     branches:
       - 'release/**'
+  # 手動でワークフローを実行できるようにする
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'リリースバージョン'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   build:

--- a/.github/workflows/tag-based-release.yml
+++ b/.github/workflows/tag-based-release.yml
@@ -175,13 +175,20 @@ jobs:
           echo "✓ Pushed changes to branch: ${{ env.BRANCH_NAME }}"
           
       # 既存のdraft-release.ymlを直接呼び出して実行
-      - name: Wait for draft release workflow
+      - name: Trigger draft release workflow manually
         if: steps.commit-changes.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # リリースブランチをプッシュした後、ドラフトリリースワークフローが起動するのを待つ
-          echo "リリースブランチがプッシュされました。ドラフトリリースワークフローが起動されます。"
-          # 10秒待って、ワークフローがGitHubに登録されるのを確認
-          sleep 10
+          # リリースブランチをプッシュした後、ドラフトリリースワークフローを明示的に起動
+          echo "リリースブランチがプッシュされました。ドラフトリリースワークフローを手動で起動します。"
+          
+          # GitHub CLIを使ってワークフローを手動実行
+          gh workflow run draft-release.yml --ref ${{ env.BRANCH_NAME }} --repo ${{ github.repository }}
+          
+          echo "ドラフトリリースワークフローを手動でトリガーしました"
+          # ワークフローが起動するまで少し待つ
+          sleep 15
           
       # GitHub CLIでPRを作成（create-pull-requestアクションの代わりに）
       - name: Create Pull Request


### PR DESCRIPTION
## ドラフトリリースワークフローを確実に起動する改善

### 問題点
- タグベースリリースワークフローからドラフトリリースワークフローが自動的に起動されていませんでした
- 単にブランチをプッシュしただけでは、何らかの理由でワークフローのトリガーが発生していない可能性があります

### 改善点
1. **ワークフローディスパッチイベントの追加**:
   -  に  トリガーを追加し、手動および外部からの起動をサポート
   - オプションで特定のバージョンを指定可能に

2. **GitHub CLIを使用したワークフロー起動**:
   - GitHub CLIの  コマンドでドラフトリリースワークフローを直接起動
   - リリースブランチを明示的に指定してワークフローを実行

### テスト方法
新しいタグをプッシュすると、次のプロセスが実行されます:
1. タグベースリリースワークフローが起動
2. リリースブランチとPRが作成される
3. GitHub CLI経由でドラフトリリースワークフローが明示的に起動される
4. ビルドとドラフトリリース作成が行われる

この改善により、ワークフローの連携がより確実になり、シームレスなリリースプロセスが実現します。