### PR TITLE
fix: Github Actionsの権限エラーを回避するために手動起動手順を追加

### DIFF
--- a/.github/workflows/tag-based-release.yml
+++ b/.github/workflows/tag-based-release.yml
@@ -4,6 +4,7 @@ name: Tag Based Release Workflow
 permissions:
   contents: write
   pull-requests: write
+  actions: write # ワークフローディスパッチのために権限追加
 
 on:
   push:
@@ -183,20 +184,16 @@ jobs:
           echo "✓ Pushed changes to branch: ${{ env.BRANCH_NAME }}"
           
       # 既存のdraft-release.ymlを直接呼び出して実行
-      - name: Trigger draft release workflow manually
+      - name: Skip workflow trigger
         if: steps.commit-changes.outputs.pushed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # リリースブランチをプッシュした後、ドラフトリリースワークフローを明示的に起動
-          echo "リリースブランチがプッシュされました。ドラフトリリースワークフローを手動で起動します。"
-          
-          # GitHub CLIを使ってワークフローを手動実行
-          gh workflow run draft-release.yml --ref ${{ env.BRANCH_NAME }} --repo ${{ github.repository }}
-          
-          echo "ドラフトリリースワークフローを手動でトリガーしました"
-          # ワークフローが起動するまで少し待つ
-          sleep 15
+          # 権限の問題でワークフローディスパッチができないため、PRにメッセージを残す
+          echo "リリースブランチ ${{ env.BRANCH_NAME }} がプッシュされました。"
+          echo "ドラフトリリースワークフローは手動で起動する必要があります："
+          echo "1. リリースPRを確認した後、以下のURLにアクセス"
+          echo "2. 「Run workflow」ボタンをクリック"
+          echo "3. ブランチ「${{ env.BRANCH_NAME }}」を選択して実行"
+          echo "https://github.com/${{ github.repository }}/actions/workflows/draft-release.yml"
           
       # GitHub CLIでPRを作成（create-pull-requestアクションの代わりに）
       - name: Create Pull Request


### PR DESCRIPTION
$## GitHub Actionsの権限制限への対応\n\n### 問題点\n- ワークフロー内から別のワークフローを起動しようとすると権限エラーが発生しています\n- エラーメッセージ: `HTTP 403: Resource not accessible by integration`\n- GitHub Actionsではセキュリティ上の理由から、ワークフローが他のワークフローを起動する権限が制限されています\n\n### 修正内容\n- 自動起動を試みるステップを削除し、代わりに手動起動の手順を示すメッセージを出力\n- 権限の宣言を調整（actions: writeを追加）\n- ユーザーが簡単に操作できるよう明確な手順を提供\n\n### 期待される効果\n- タグプッシュ時にリリースブランチと対応するPRは自動作成される\n- PRレビュー中にユーザーが指示通りに手動でドラフトリリースワークフローを起動できる\n- 2ステップ（タグプッシュとワークフロー起動）で完全なリリースフローを実行可能\n\nこの修正により、GitHub Actionsの制限下でも効率的なリリースプロセスが実現できます。