### PR TITLE
Implement monaco-editor based DiffViewer component for ApplyDiffEdit tool results

### DIFF
--- a/src/renderer/src/i18n/locales/chat/tools.ts
+++ b/src/renderer/src/i18n/locales/chat/tools.ts
@@ -1,5 +1,13 @@
 export const tools = {
   en: {
+    'file changes': {
+      fileChanges: 'File Changes',
+      original: 'Original',
+      updated: 'Updated',
+      added: 'Added',
+      removed: 'Removed',
+      noChanges: 'No changes detected'
+    },
     'Available Tools': 'Available Tools',
     'Choose the tools': 'Choose the tools you want to enable for the AI assistant',
     // Common UI text
@@ -401,6 +409,14 @@ export const tools = {
     }
   },
   ja: {
+    'file changes': {
+      fileChanges: 'ファイルの変更',
+      original: '元の内容',
+      updated: '更新後の内容',
+      added: '追加された内容',
+      removed: '削除された内容',
+      noChanges: '変更はありません'
+    },
     'Available Tools': '利用可能なツール',
     'Choose the tools': 'AIアシスタントで使用するツールを選択してください',
     // Common UI text

--- a/src/renderer/src/i18n/locales/en.ts
+++ b/src/renderer/src/i18n/locales/en.ts
@@ -332,7 +332,18 @@ const FileChanges = {
   updated: 'Updated',
   added: 'Added',
   removed: 'Removed',
-  noChanges: 'No changes detected'
+  noChanges: 'No changes detected',
+  fileDiff: 'File Diff',
+  copyOriginal: 'Copy Original',
+  copyUpdated: 'Copy Updated',
+  originalTextCopied: 'Original text copied to clipboard',
+  updatedTextCopied: 'Updated text copied to clipboard',
+  filePathCopied: 'File path copied to clipboard',
+  failedToCopy: 'Failed to copy text',
+  lines: 'lines',
+  changed: 'Changed',
+  expand: 'Expand',
+  collapse: 'Collapse'
 }
 
 const en = {

--- a/src/renderer/src/i18n/locales/en.ts
+++ b/src/renderer/src/i18n/locales/en.ts
@@ -327,12 +327,21 @@ const CodeBlock = {
   'Camera Device': 'Camera Device'
 }
 
+const FileChanges = {
+  original: 'Original',
+  updated: 'Updated',
+  added: 'Added',
+  removed: 'Removed',
+  noChanges: 'No changes detected'
+}
+
 const en = {
   ...HomePage,
   ...SettingPage,
   ...StepFunctionsGeneratorPage,
   ...chatPage.en,
   ...SpeakPage,
+  ...FileChanges,
   ...WebsiteGeneratorPage,
   ...Translation,
   ...CodeBlock,

--- a/src/renderer/src/i18n/locales/ja.ts
+++ b/src/renderer/src/i18n/locales/ja.ts
@@ -356,7 +356,18 @@ const FileChanges = {
   updated: '更新後の内容',
   added: '追加された内容',
   removed: '削除された内容',
-  noChanges: '変更はありません'
+  noChanges: '変更はありません',
+  fileDiff: 'ファイル差分',
+  copyOriginal: '元のテキストをコピー',
+  copyUpdated: '更新後のテキストをコピー',
+  originalTextCopied: '元のテキストをクリップボードにコピーしました',
+  updatedTextCopied: '更新後のテキストをクリップボードにコピーしました',
+  filePathCopied: 'ファイルパスをクリップボードにコピーしました',
+  failedToCopy: 'テキストのコピーに失敗しました',
+  lines: '行',
+  changed: '変更',
+  expand: '拡大',
+  collapse: '折りたたむ'
 }
 
 const ja = {

--- a/src/renderer/src/i18n/locales/ja.ts
+++ b/src/renderer/src/i18n/locales/ja.ts
@@ -351,12 +351,21 @@ const CodeBlock = {
   'Camera Device': 'カメラデバイス'
 }
 
+const FileChanges = {
+  original: '元の内容',
+  updated: '更新後の内容',
+  added: '追加された内容',
+  removed: '削除された内容',
+  noChanges: '変更はありません'
+}
+
 const ja = {
   ...HomePage,
   ...SettingPage,
   ...StepFunctionsGeneratorPage,
   ...chatPage.ja,
   ...SpeakPage,
+  ...FileChanges,
   ...WebsiteGeneratorPage,
   ...Translation,
   ...CodeBlock,

--- a/src/renderer/src/pages/ChatPage/components/CodeBlocks/ApplyDiffEdit/ApplyDiffEditResult.tsx
+++ b/src/renderer/src/pages/ChatPage/components/CodeBlocks/ApplyDiffEdit/ApplyDiffEditResult.tsx
@@ -1,0 +1,159 @@
+import React, { useState, useEffect, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import * as Diff from 'diff'
+import { FiCopy, FiMaximize, FiMinimize, FiCheck } from 'react-icons/fi'
+import toast from 'react-hot-toast'
+
+interface ApplyDiffEditResultProps {
+  response: {
+    success: boolean
+    error?: string
+    result?: {
+      path: string
+      originalText: string
+      updatedText: string
+    }
+  }
+}
+
+export const ApplyDiffEditResult: React.FC<ApplyDiffEditResultProps> = ({ response }) => {
+  const { t } = useTranslation()
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [showCopyConfirmation, setShowCopyConfirmation] = useState(false)
+
+  // Reset copy confirmation after 2 seconds
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout
+    if (showCopyConfirmation) {
+      timeoutId = setTimeout(() => {
+        setShowCopyConfirmation(false)
+      }, 2000)
+    }
+    return () => {
+      if (timeoutId) clearTimeout(timeoutId)
+    }
+  }, [showCopyConfirmation])
+
+  // Generate the diff between the original and updated text
+  const diffParts = useMemo(() => {
+    if (!response.success || !response.result) return []
+    return Diff.diffLines(response.result.originalText, response.result.updatedText)
+  }, [response])
+
+  // Handle copy button click
+  const handleCopy = (text: string) => {
+    navigator.clipboard.writeText(text)
+    toast.success(t('common.copied'))
+    setShowCopyConfirmation(true)
+  }
+
+  // If there was an error
+  if (!response.success) {
+    return (
+      <div className="bg-red-50 dark:bg-red-900/20 text-red-800 dark:text-red-200 p-4 rounded-md">
+        <h3 className="text-lg font-semibold">{t('errors.failedToApplyChanges')}</h3>
+        <p>{response.error}</p>
+      </div>
+    )
+  }
+
+  // If there's no result data
+  if (!response.result) {
+    return (
+      <div className="bg-yellow-50 dark:bg-yellow-900/20 text-yellow-800 dark:text-yellow-200 p-4 rounded-md">
+        <h3 className="text-lg font-semibold">{t('common.noResults')}</h3>
+      </div>
+    )
+  }
+
+  return (
+    <div className={`border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden ${isExpanded ? 'fixed inset-5 z-50 bg-white dark:bg-gray-900' : 'max-h-[60vh]'}`}>
+      {/* Header */}
+      <div className="bg-gray-100 dark:bg-gray-800 px-4 py-3 flex justify-between items-center">
+        <div>
+          <h3 className="font-medium text-base">
+            {t('tools.fileChanges')}: <span className="font-mono text-sm">{response.result.path.split('/').pop()}</span>
+          </h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400 font-mono truncate">
+            {response.result.path}
+          </p>
+        </div>
+        <div className="flex space-x-2">
+          <button
+            onClick={() => handleCopy(response.result!.updatedText)}
+            className="p-1.5 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300"
+            title={t('common.copy')}
+          >
+            {showCopyConfirmation ? <FiCheck /> : <FiCopy />}
+          </button>
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="p-1.5 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300"
+            title={isExpanded ? t('common.minimize') : t('common.maximize')}
+          >
+            {isExpanded ? <FiMinimize /> : <FiMaximize />}
+          </button>
+        </div>
+      </div>
+
+      {/* Diff Display */}
+      <div className="grid grid-cols-2 divide-x divide-gray-200 dark:divide-gray-700 overflow-auto">
+        {/* Left side - Original Text */}
+        <div className="overflow-auto">
+          <div className="p-1 bg-gray-50 dark:bg-gray-800/50 text-xs text-center text-gray-600 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+            {t('common.original')}
+          </div>
+          <pre className="p-4 text-sm font-mono whitespace-pre-wrap overflow-auto">
+            {diffParts.map((part, index) => (
+              <span
+                key={index}
+                className={`${part.removed ? 'bg-red-100 dark:bg-red-900/30 text-red-900 dark:text-red-300' : ''}`}
+              >
+                {part.value}
+              </span>
+            ))}
+          </pre>
+        </div>
+        
+        {/* Right side - Updated Text */}
+        <div className="overflow-auto">
+          <div className="p-1 bg-gray-50 dark:bg-gray-800/50 text-xs text-center text-gray-600 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+            {t('common.updated')}
+          </div>
+          <pre className="p-4 text-sm font-mono whitespace-pre-wrap overflow-auto">
+            {diffParts.map((part, index) => (
+              <span
+                key={index}
+                className={`${part.added ? 'bg-green-100 dark:bg-green-900/30 text-green-900 dark:text-green-300' : ''}`}
+              >
+                {part.value}
+              </span>
+            ))}
+          </pre>
+        </div>
+      </div>
+      
+      {/* Summary Footer */}
+      <div className="px-4 py-2 bg-gray-50 dark:bg-gray-800 text-xs text-gray-500 dark:text-gray-400 border-t border-gray-200 dark:border-gray-700">
+        {diffParts.filter(part => part.added || part.removed).length > 0 ? (
+          <p>
+            {diffParts.filter(part => part.added).length > 0 && (
+              <span className="inline-flex items-center mr-3">
+                <span className="inline-block w-3 h-3 mr-1 bg-green-100 dark:bg-green-900/30 border border-green-300 dark:border-green-700"></span>
+                {t('common.added')}
+              </span>
+            )}
+            {diffParts.filter(part => part.removed).length > 0 && (
+              <span className="inline-flex items-center">
+                <span className="inline-block w-3 h-3 mr-1 bg-red-100 dark:bg-red-900/30 border border-red-300 dark:border-red-700"></span>
+                {t('common.removed')}
+              </span>
+            )}
+          </p>
+        ) : (
+          <p>{t('tools.noChanges')}</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/pages/ChatPage/components/CodeBlocks/ApplyDiffEdit/ApplyDiffEditResult.tsx
+++ b/src/renderer/src/pages/ChatPage/components/CodeBlocks/ApplyDiffEdit/ApplyDiffEditResult.tsx
@@ -1,51 +1,10 @@
-import React, { useState, useEffect, useMemo } from 'react'
+import React from 'react'
 import { useTranslation } from 'react-i18next'
-import * as Diff from 'diff'
-import { FiCopy, FiMaximize, FiMinimize, FiCheck } from 'react-icons/fi'
-import toast from 'react-hot-toast'
-
-interface ApplyDiffEditResultProps {
-  response: {
-    success: boolean
-    error?: string
-    result?: {
-      path: string
-      originalText: string
-      updatedText: string
-    }
-  }
-}
+import { DiffViewer } from './DiffViewer'
+import { ApplyDiffEditResultProps } from './types'
 
 export const ApplyDiffEditResult: React.FC<ApplyDiffEditResultProps> = ({ response }) => {
   const { t } = useTranslation()
-  const [isExpanded, setIsExpanded] = useState(false)
-  const [showCopyConfirmation, setShowCopyConfirmation] = useState(false)
-
-  // Reset copy confirmation after 2 seconds
-  useEffect(() => {
-    let timeoutId: NodeJS.Timeout
-    if (showCopyConfirmation) {
-      timeoutId = setTimeout(() => {
-        setShowCopyConfirmation(false)
-      }, 2000)
-    }
-    return () => {
-      if (timeoutId) clearTimeout(timeoutId)
-    }
-  }, [showCopyConfirmation])
-
-  // Generate the diff between the original and updated text
-  const diffParts = useMemo(() => {
-    if (!response.success || !response.result) return []
-    return Diff.diffLines(response.result.originalText, response.result.updatedText)
-  }, [response])
-
-  // Handle copy button click
-  const handleCopy = (text: string) => {
-    navigator.clipboard.writeText(text)
-    toast.success(t('common.copied'))
-    setShowCopyConfirmation(true)
-  }
 
   // If there was an error
   if (!response.success) {
@@ -67,93 +26,10 @@ export const ApplyDiffEditResult: React.FC<ApplyDiffEditResultProps> = ({ respon
   }
 
   return (
-    <div className={`border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden ${isExpanded ? 'fixed inset-5 z-50 bg-white dark:bg-gray-900' : 'max-h-[60vh]'}`}>
-      {/* Header */}
-      <div className="bg-gray-100 dark:bg-gray-800 px-4 py-3 flex justify-between items-center">
-        <div>
-          <h3 className="font-medium text-base">
-            {t('tools.fileChanges')}: <span className="font-mono text-sm">{response.result.path.split('/').pop()}</span>
-          </h3>
-          <p className="text-xs text-gray-500 dark:text-gray-400 font-mono truncate">
-            {response.result.path}
-          </p>
-        </div>
-        <div className="flex space-x-2">
-          <button
-            onClick={() => handleCopy(response.result!.updatedText)}
-            className="p-1.5 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300"
-            title={t('common.copy')}
-          >
-            {showCopyConfirmation ? <FiCheck /> : <FiCopy />}
-          </button>
-          <button
-            onClick={() => setIsExpanded(!isExpanded)}
-            className="p-1.5 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300"
-            title={isExpanded ? t('common.minimize') : t('common.maximize')}
-          >
-            {isExpanded ? <FiMinimize /> : <FiMaximize />}
-          </button>
-        </div>
-      </div>
-
-      {/* Diff Display */}
-      <div className="grid grid-cols-2 divide-x divide-gray-200 dark:divide-gray-700 overflow-auto">
-        {/* Left side - Original Text */}
-        <div className="overflow-auto">
-          <div className="p-1 bg-gray-50 dark:bg-gray-800/50 text-xs text-center text-gray-600 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
-            {t('common.original')}
-          </div>
-          <pre className="p-4 text-sm font-mono whitespace-pre-wrap overflow-auto">
-            {diffParts.map((part, index) => (
-              <span
-                key={index}
-                className={`${part.removed ? 'bg-red-100 dark:bg-red-900/30 text-red-900 dark:text-red-300' : ''}`}
-              >
-                {part.value}
-              </span>
-            ))}
-          </pre>
-        </div>
-        
-        {/* Right side - Updated Text */}
-        <div className="overflow-auto">
-          <div className="p-1 bg-gray-50 dark:bg-gray-800/50 text-xs text-center text-gray-600 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
-            {t('common.updated')}
-          </div>
-          <pre className="p-4 text-sm font-mono whitespace-pre-wrap overflow-auto">
-            {diffParts.map((part, index) => (
-              <span
-                key={index}
-                className={`${part.added ? 'bg-green-100 dark:bg-green-900/30 text-green-900 dark:text-green-300' : ''}`}
-              >
-                {part.value}
-              </span>
-            ))}
-          </pre>
-        </div>
-      </div>
-      
-      {/* Summary Footer */}
-      <div className="px-4 py-2 bg-gray-50 dark:bg-gray-800 text-xs text-gray-500 dark:text-gray-400 border-t border-gray-200 dark:border-gray-700">
-        {diffParts.filter(part => part.added || part.removed).length > 0 ? (
-          <p>
-            {diffParts.filter(part => part.added).length > 0 && (
-              <span className="inline-flex items-center mr-3">
-                <span className="inline-block w-3 h-3 mr-1 bg-green-100 dark:bg-green-900/30 border border-green-300 dark:border-green-700"></span>
-                {t('common.added')}
-              </span>
-            )}
-            {diffParts.filter(part => part.removed).length > 0 && (
-              <span className="inline-flex items-center">
-                <span className="inline-block w-3 h-3 mr-1 bg-red-100 dark:bg-red-900/30 border border-red-300 dark:border-red-700"></span>
-                {t('common.removed')}
-              </span>
-            )}
-          </p>
-        ) : (
-          <p>{t('tools.noChanges')}</p>
-        )}
-      </div>
-    </div>
+    <DiffViewer
+      originalText={response.result.originalText}
+      updatedText={response.result.updatedText}
+      filePath={response.result.path}
+    />
   )
 }

--- a/src/renderer/src/pages/ChatPage/components/CodeBlocks/ApplyDiffEdit/DiffViewer.tsx
+++ b/src/renderer/src/pages/ChatPage/components/CodeBlocks/ApplyDiffEdit/DiffViewer.tsx
@@ -1,0 +1,183 @@
+import React, { useMemo, useState } from 'react'
+import { DiffEditor } from '@monaco-editor/react'
+import { useTranslation } from 'react-i18next'
+import { FiCopy, FiMaximize2, FiMinimize2 } from 'react-icons/fi'
+import toast from 'react-hot-toast'
+import { DiffViewerProps } from './types'
+
+/**
+ * Get language from file extension
+ */
+const getLanguageFromPath = (filePath: string): string => {
+  const extension = filePath.split('.').pop()?.toLowerCase()
+
+  const languageMap: Record<string, string> = {
+    ts: 'typescript',
+    tsx: 'typescript',
+    js: 'javascript',
+    jsx: 'javascript',
+    py: 'python',
+    java: 'java',
+    cpp: 'cpp',
+    c: 'c',
+    cs: 'csharp',
+    php: 'php',
+    rb: 'ruby',
+    go: 'go',
+    rs: 'rust',
+    kt: 'kotlin',
+    swift: 'swift',
+    css: 'css',
+    scss: 'scss',
+    less: 'less',
+    html: 'html',
+    xml: 'xml',
+    json: 'json',
+    yaml: 'yaml',
+    yml: 'yaml',
+    md: 'markdown',
+    sql: 'sql',
+    sh: 'shell',
+    bash: 'shell',
+    zsh: 'shell',
+    ps1: 'powershell',
+    dockerfile: 'dockerfile'
+  }
+
+  return languageMap[extension || ''] || 'plaintext'
+}
+
+export const DiffViewer: React.FC<DiffViewerProps> = ({
+  originalText,
+  updatedText,
+  filePath,
+  language
+}) => {
+  const { t } = useTranslation()
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  const detectedLanguage = useMemo(() => {
+    return language || getLanguageFromPath(filePath)
+  }, [language, filePath])
+
+  // Calculate diff statistics
+  const diffStats = useMemo(() => {
+    const originalLines = originalText.split('\n')
+    const updatedLines = updatedText.split('\n')
+
+    return {
+      originalLines: originalLines.length,
+      updatedLines: updatedLines.length,
+      linesChanged: Math.abs(updatedLines.length - originalLines.length)
+    }
+  }, [originalText, updatedText])
+
+  const handleCopyOriginal = () => {
+    navigator.clipboard
+      .writeText(originalText)
+      .then(() => toast.success(t('Original text copied to clipboard')))
+      .catch(() => toast.error(t('Failed to copy text')))
+  }
+
+  const handleCopyUpdated = () => {
+    navigator.clipboard
+      .writeText(updatedText)
+      .then(() => toast.success(t('Updated text copied to clipboard')))
+      .catch(() => toast.error(t('Failed to copy text')))
+  }
+
+  const handleCopyFilePath = () => {
+    navigator.clipboard
+      .writeText(filePath)
+      .then(() => toast.success(t('File path copied to clipboard')))
+      .catch(() => toast.error(t('Failed to copy file path')))
+  }
+
+  return (
+    <div className="border rounded-lg dark:border-gray-700 bg-white dark:bg-gray-800">
+      {/* Header */}
+      <div className="flex items-center justify-between p-3 border-b dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            {t('File Diff')}:
+          </span>
+          <button
+            onClick={handleCopyFilePath}
+            className="text-sm text-blue-600 dark:text-blue-400 hover:underline font-mono truncate max-w-xs"
+            title={filePath}
+          >
+            {filePath}
+          </button>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-gray-500 bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded">
+            {detectedLanguage}
+          </span>
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded"
+            title={isExpanded ? t('Collapse') : t('Expand')}
+          >
+            {isExpanded ? <FiMinimize2 className="w-4 h-4" /> : <FiMaximize2 className="w-4 h-4" />}
+          </button>
+        </div>
+      </div>
+
+      {/* Stats */}
+      <div className="flex items-center gap-4 px-3 py-2 text-xs text-gray-600 dark:text-gray-400 bg-gray-50 dark:bg-gray-900 border-b dark:border-gray-700">
+        <span>
+          {t('Original')}: {diffStats.originalLines} {t('lines')}
+        </span>
+        <span>
+          {t('Updated')}: {diffStats.updatedLines} {t('lines')}
+        </span>
+        <span>
+          {t('Changed')}: {diffStats.linesChanged} {t('lines')}
+        </span>
+      </div>
+
+      {/* Copy buttons */}
+      <div className="flex gap-2 px-3 py-2 bg-gray-50 dark:bg-gray-900 border-b dark:border-gray-700">
+        <button
+          onClick={handleCopyOriginal}
+          className="flex items-center gap-1 text-xs px-2 py-1 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 rounded"
+        >
+          <FiCopy className="w-3 h-3" />
+          {t('Copy Original')}
+        </button>
+        <button
+          onClick={handleCopyUpdated}
+          className="flex items-center gap-1 text-xs px-2 py-1 bg-blue-200 dark:bg-blue-700 hover:bg-blue-300 dark:hover:bg-blue-600 rounded"
+        >
+          <FiCopy className="w-3 h-3" />
+          {t('Copy Updated')}
+        </button>
+      </div>
+
+      {/* Diff Editor */}
+      <div className={`${isExpanded ? 'h-96' : 'h-64'} transition-all duration-200`}>
+        <DiffEditor
+          original={originalText}
+          modified={updatedText}
+          language={detectedLanguage}
+          theme="vs-dark"
+          options={{
+            readOnly: true,
+            renderSideBySide: true,
+            enableSplitViewResizing: false,
+            renderOverviewRuler: false,
+            folding: false,
+            lineNumbers: 'on',
+            minimap: { enabled: false },
+            scrollBeyondLastLine: false,
+            wordWrap: 'on',
+            automaticLayout: true,
+            fontSize: 12,
+            diffCodeLens: true,
+            ignoreTrimWhitespace: false
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/pages/ChatPage/components/CodeBlocks/ApplyDiffEdit/types.ts
+++ b/src/renderer/src/pages/ChatPage/components/CodeBlocks/ApplyDiffEdit/types.ts
@@ -1,0 +1,24 @@
+/**
+ * Props for the DiffViewer component
+ */
+export interface DiffViewerProps {
+  originalText: string
+  updatedText: string
+  filePath: string
+  language?: string
+}
+
+/**
+ * Props for ApplyDiffEditResult component
+ */
+export interface ApplyDiffEditResultProps {
+  response: {
+    success: boolean
+    error?: string
+    result?: {
+      path: string
+      originalText: string
+      updatedText: string
+    }
+  }
+}

--- a/src/renderer/src/pages/ChatPage/components/CodeBlocks/JSONCodeBlock.tsx
+++ b/src/renderer/src/pages/ChatPage/components/CodeBlocks/JSONCodeBlock.tsx
@@ -9,6 +9,7 @@ import { RecognizeImageResult } from './RecognizeImage/RecognizeImageResult'
 import { CodeInterpreterResult } from './CodeInterpreter/CodeInterpreterResult'
 import { ScreenCaptureResult } from './ScreenCapture/ScreenCaptureResult'
 import { CameraCaptureResult } from './CameraCapture/CameraCaptureResult'
+import { ApplyDiffEditResult } from './ApplyDiffEdit/ApplyDiffEditResult'
 import { AsyncTaskCard, AsyncTaskInfo } from '../CodeInterpreter/AsyncTaskCard'
 
 interface RetrieveResponse {
@@ -139,6 +140,10 @@ export const JSONCodeBlock: React.FC<{ json: any }> = ({ json }) => {
         <CodeInterpreterResult response={json} />
       </div>
     )
+  }
+
+  if (json.name === 'applyDiffEdit') {
+    return <ApplyDiffEditResult response={json} />
   }
 
   const jsonStr = JSON.stringify(json, null, 2)


### PR DESCRIPTION
This PR updates the ApplyDiffEdit tool results display with a monaco-editor based side-by-side diff view.

## Changes:

1. Added a new `DiffViewer.tsx` component that uses `@monaco-editor/react` to display file diffs in a side-by-side view
2. Created a types file to define shared interfaces
3. Simplified the `ApplyDiffEditResult.tsx` component to use the new DiffViewer
4. Added new translations for diff viewer UI elements
5. Added utility function to detect file language based on file extension

The monaco-editor based diff viewer offers several advantages:
- Better syntax highlighting based on file type
- Improved line-by-line comparison
- More familiar interface for developers used to VSCode
- Expandable view for better readability
- Advanced diff visualization with color coding

This implementation provides a richer experience for reviewing file changes, making it easier to understand and verify modifications.

Fixes #17

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:1749939903152859 -->