### PR TITLE
fix: システムプロンプト自動生成中に入力フォームを無効化

### DIFF
--- a/src/renderer/src/pages/ChatPage/components/AgentForm/SystemPromptSection.tsx
+++ b/src/renderer/src/pages/ChatPage/components/AgentForm/SystemPromptSection.tsx
@@ -164,9 +164,10 @@ export const SystemPromptSection: React.FC<SystemPromptSectionProps> = ({
           <textarea
             value={additionalInstruction || ''}
             onChange={handleAdditionalInstructionChange}
-            className="block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800
+            disabled={isGenerating || isGeneratingVoiceChat}
+            className={`block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800
               text-gray-900 dark:text-gray-100 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm
-              h-[150px]"
+              h-[150px] ${(isGenerating || isGeneratingVoiceChat) ? 'opacity-50 cursor-not-allowed' : ''}`}
             placeholder={t(
               'additionalInstructionPlaceholder',
               'Enter additional instructions for system prompt generation...'
@@ -208,9 +209,10 @@ export const SystemPromptSection: React.FC<SystemPromptSectionProps> = ({
           <textarea
             value={system}
             onChange={(e) => onChange(e.target.value)}
-            className="block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800
+            disabled={isGenerating || isGeneratingVoiceChat}
+            className={`block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800
               text-gray-900 dark:text-gray-100 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm
-              h-[512px]"
+              h-[512px] ${(isGenerating || isGeneratingVoiceChat) ? 'opacity-50 cursor-not-allowed' : ''}`}
             required
             placeholder={t('systemPromptPlaceholder')}
           />


### PR DESCRIPTION
## 問題

エージェント編集モーダル画面において、システムプロンプトの自動生成を押すとその後にシステムプロンプトの入力フォームを変更しても変更ができない問題がありました。

## 根本原因

- システムプロンプトのテキストエリアに `disabled` 属性が設定されていなかった
- 自動生成中でもユーザーが入力できてしまう状態で、生成完了時に入力内容が上書きされる競合状態が発生

## 修正内容

1. **システムプロンプトテキストエリアの無効化制御を追加**
   - `disabled={isGenerating || isGeneratingVoiceChat}` 属性を追加
   - 生成中は入力を無効化し、生成完了後に自動的に有効化される

2. **追加指示テキストエリアも同様に修正**
   - 一貫性のため同じ無効化制御を適用

3. **視覚的フィードバックを追加**
   - 無効化時に `opacity-50` と `cursor-not-allowed` クラスを適用
   - ユーザーに生成中であることを明確に示す

## テスト

修正により以下の動作が期待されます：

1. システムプロンプト自動生成ボタンを押すと、入力フォームが無効化される
2. 生成完了後、入力フォームが有効化され、編集可能になる
3. 音声チャット用プロンプト生成時も同様の動作

## 影響範囲

- `SystemPromptSection.tsx` のみの修正
- 既存の機能には影響なし
- バックワード互換性を維持

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:1750145495304389 -->