### PR TITLE
fix: Handle empty strings in JSON parse for toolUse input

### DIFF
--- a/src/renderer/src/pages/ChatPage/hooks/useAgentChat.ts
+++ b/src/renderer/src/pages/ChatPage/hooks/useAgentChat.ts
@@ -408,16 +408,21 @@ export const useAgentChat = (
         } else if (json.contentBlockStop) {
           if (toolUse) {
             let parseInput: any
-            try {
-              parseInput = JSON.parse(input)
-            } catch (e) {
-              parseInput = {
-                __jsonParseError: true,
-                originalInput: input,
-                maxTokens: inferenceParams.maxTokens,
-                error:
-                  (e instanceof Error ? e.message : 'JSON parse failed') +
-                  '\n JSON parsing failed. This error might have occurred because the token limit (character count) was exceeded while the AI was trying to create the input JSON for tool use. \nThe output needs to fit within the maxTokens limit.'
+            // 空文字列の場合は空オブジェクトを使用（JSONパースエラーとしない）
+            if (input === '' || input === '""' || input === "''") {
+              parseInput = {}
+            } else {
+              try {
+                parseInput = JSON.parse(input)
+              } catch (e) {
+                parseInput = {
+                  __jsonParseError: true,
+                  originalInput: input,
+                  maxTokens: inferenceParams.maxTokens,
+                  error:
+                    (e instanceof Error ? e.message : 'JSON parse failed') +
+                    '\n JSON parsing failed. This error might have occurred because the token limit (character count) was exceeded while the AI was trying to create the input JSON for tool use. \nThe output needs to fit within the maxTokens limit.'
+                }
               }
             }
 


### PR DESCRIPTION
- Add check for empty strings ('', '""', "''") before JSON.parse()
- Return empty object {} instead of JSON parse error for empty strings
- Maintains backward compatibility for actual JSON parse errors

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
