### PR TITLE
ToolResult Content Chunker

### DIFF
--- a/src/preload/lib/contentChunker.ts
+++ b/src/preload/lib/contentChunker.ts
@@ -1,3 +1,5 @@
+import { ConfigStore } from '../store'
+
 export interface ContentChunk {
   index: number
   total: number
@@ -6,11 +8,19 @@ export interface ContentChunk {
     url?: string
     filePath?: string
     timestamp: number
+    tokenLimit?: number
   }
 }
 
 export class ContentChunker {
   private static readonly MAX_CHUNK_SIZE = 50000 // 約50,000文字（Claude 3 Haikuの制限を考慮）
+  private static readonly CHARS_PER_TOKEN = 4 // 簡易的なトークン推定（文字数 ÷ 4）
+
+  private store: ConfigStore
+
+  constructor(store: ConfigStore) {
+    this.store = store
+  }
 
   static splitContent(
     content: string,
@@ -44,6 +54,68 @@ export class ContentChunker {
     }
 
     return chunks
+  }
+
+  /**
+   * トークン数ベースでコンテンツを分割
+   */
+  static splitContentByTokenLimit(
+    content: string,
+    maxTokens: number,
+    metadata?: { url?: string; filePath?: string }
+  ): ContentChunk[] {
+    const chunks: ContentChunk[] = []
+    const timestamp = Date.now()
+
+    // トークン数から文字数の上限を計算（安全のため80%を使用）
+    const maxCharsPerChunk = Math.floor(maxTokens * this.CHARS_PER_TOKEN * 0.8)
+
+    // コンテンツを適切なサイズに分割
+    const totalChunks = Math.ceil(content.length / maxCharsPerChunk)
+
+    for (let i = 0; i < totalChunks; i++) {
+      const start = i * maxCharsPerChunk
+      const end = Math.min((i + 1) * maxCharsPerChunk, content.length)
+
+      chunks.push({
+        index: i + 1,
+        total: totalChunks,
+        content: content.slice(start, end),
+        metadata: {
+          ...metadata,
+          timestamp,
+          tokenLimit: maxTokens
+        }
+      })
+    }
+
+    return chunks
+  }
+
+  /**
+   * store設定に基づいてコンテンツを分割
+   */
+  splitContent(content: string, metadata?: { url?: string; filePath?: string }): ContentChunk[] {
+    const inferenceParams = this.store.get('inferenceParams')
+    const maxTokens = inferenceParams?.maxTokens || 4096
+    return ContentChunker.splitContentByTokenLimit(content, maxTokens, metadata)
+  }
+
+  /**
+   * コンテンツの推定トークン数を計算
+   */
+  static estimateToken(content: string): number {
+    return Math.ceil(content.length / this.CHARS_PER_TOKEN)
+  }
+
+  /**
+   * store設定に基づいてコンテンツが制限を超えるかチェック
+   */
+  isContentTooLarge(content: string): boolean {
+    const inferenceParams = this.store.get('inferenceParams')
+    const maxTokens = inferenceParams?.maxTokens || 4096
+    const estimatedTokens = ContentChunker.estimateToken(content)
+    return estimatedTokens > maxTokens
   }
 
   public static extractMainContent(html: string): string {


### PR DESCRIPTION
# ToolResult Content Chunker

## Description
Implements automatic content chunking for tool results to prevent token limit errors. When tool output exceeds the configured token limit, it automatically splits content and returns the first chunk with truncation notice.

## Changes
- **ContentChunker**: Added token-based splitting with ConfigStore integration
- **BaseTool**: Added automatic result processing with chunking support

## Key Features
- Token estimation (chars ÷ 4) with 80% safety margin
- Dynamic limits based on user's `maxTokens` setting
- Preserves original result types
- Optional chunking control via `shouldUseChunking()`

## Testing
Test with large files using readFiles tool and verify chunking behavior in console logs.