### PR TITLE
MCPClient の URL 接続に認証ヘッダーのサポートを追加

### DIFF
--- a/src/common/mcp/schemas.ts
+++ b/src/common/mcp/schemas.ts
@@ -17,7 +17,8 @@ export const mcpServerConfigSchema = z.object({
       // URL形式のサーバー設定
       z.object({
         url: z.string(),
-        enabled: z.boolean().optional()
+        enabled: z.boolean().optional(),
+        headers: z.record(z.string(), z.string()).optional()
       })
     ])
   )

--- a/src/main/mcp/index.ts
+++ b/src/main/mcp/index.ts
@@ -170,11 +170,12 @@ export const initMcpFromAgentConfig = async (mcpServers: McpServerConfig[] = [])
             (acc, server) => {
               acc[server.name] = {
                 url: server.url,
-                enabled: true
+                enabled: true,
+                headers: server.headers || undefined
               }
               return acc
             },
-            {} as Record<string, { url: string; enabled?: boolean }>
+            {} as Record<string, { url: string; enabled?: boolean; headers?: Record<string, string> }>
           )
         }
       }
@@ -215,7 +216,8 @@ export const initMcpFromAgentConfig = async (mcpServers: McpServerConfig[] = [])
             console.log(
               `[Main Process] Connecting to URL server: ${serverConfig.name} (${serverConfig.url})`
             )
-            const client = await MCPClient.fromUrl(serverConfig.url)
+            // headers が存在する場合は渡す
+            const client = await MCPClient.fromUrl(serverConfig.url, serverConfig.headers)
             console.log(`[Main Process] Successfully connected to URL server: ${serverConfig.name}`)
             return { name: serverConfig.name, client }
           } catch (e) {
@@ -389,7 +391,7 @@ export const testMcpServerConnection = async (
           }
         }
       }
-      client = await MCPClient.fromUrl(mcpServer.url)
+      client = await MCPClient.fromUrl(mcpServer.url, mcpServer.headers)
     } else {
       return {
         success: false,

--- a/src/main/mcp/mcp-client.ts
+++ b/src/main/mcp/mcp-client.ts
@@ -38,18 +38,26 @@ export class MCPClient {
     return client
   }
 
-  static async fromUrl(url: string) {
+  static async fromUrl(url: string, headers?: Record<string, string>) {
     const baseUrl = new URL(url)
     try {
       const client = new MCPClient()
-      client.transport = new StreamableHTTPClientTransport(baseUrl)
+      // StreamableHTTPClientTransportにはヘッダー情報を渡す
+      client.transport = new StreamableHTTPClientTransport(
+        baseUrl,
+        headers ? { headers } : undefined
+      )
       await client.connectAndInitialize()
       console.log('[Main Process] Connected using Streamable HTTP transport')
       return client
     } catch (error) {
       console.log('[Main Process] Streamable HTTP connection failed, falling back to SSE transport')
       const client = new MCPClient()
-      client.transport = new SSEClientTransport(baseUrl)
+      // SSEClientTransportにもヘッダー情報を渡す
+      client.transport = new SSEClientTransport(
+        baseUrl,
+        headers ? { headers } : undefined
+      )
       await client.connectAndInitialize()
       console.log('[Main Process] Connected using SSE transport')
       return client

--- a/src/main/services/strandsAgentsConverter/codeGenerator.ts
+++ b/src/main/services/strandsAgentsConverter/codeGenerator.ts
@@ -396,7 +396,10 @@ ${clientVarName}_client = MCPClient(lambda: stdio_client(
             (server) =>
               `  - name: "${server.original.name}"\n` +
               `    command: "${server.original.command}"\n` +
-              `    args: ${JSON.stringify(server.original.args)}`
+              `    args: ${JSON.stringify(server.original.args)}` +
+              (server.original.headers
+                ? `\n    headers: ${JSON.stringify(server.original.headers)}`
+                : '')
           )
           .join('\n')
     }

--- a/src/types/agent-chat.ts
+++ b/src/types/agent-chat.ts
@@ -272,6 +272,8 @@ export interface McpServerConfig {
   env?: Record<string, string>
   // URL形式用
   url?: string
+  // 認証などのHTTPヘッダー（URLベースの接続用）
+  headers?: Record<string, string>
 }
 
 // Tavily検索設定の型定義


### PR DESCRIPTION
## 概要

MCPClient で URL ベース接続（SSEEvents, StreamableHttp）を使用する際に、認証ヘッダーなどの HTTP ヘッダーを設定できる機能を追加しました。

## 変更内容

1. **McpServerConfig インターフェースの拡張**：
   - `headers?: Record<string, string>` プロパティを追加して認証ヘッダーなどのHTTPヘッダーをサポート

2. **MCPClient の fromUrl メソッドの強化**：
   - `headers` パラメータを受け取るように拡張
   - StreamableHTTPClientTransport と SSEClientTransport の両方にヘッダー情報を渡す機能を追加

3. **スキーマ定義の更新**：
   - mcpServerConfigSchema の URL 形式サーバー設定に `headers` プロパティを追加
   
4. **URL接続処理の更新**：
   - `initMcpFromAgentConfig` 関数内で URL 接続時にヘッダー情報を渡すよう更新
   - `testMcpServerConnection` 関数も同様に更新

5. **Strands エージェント変換処理の更新**：
   - ヘッダー情報を含む設定ファイルを生成できるよう修正

## 使用例

この変更により、次のような設定でヘッダー付きMCP接続が可能になります：

```json
{
  "name": "authenticated-api",
  "url": "https://api.example.com/mcp",
  "headers": {
    "Authorization": "Bearer token123",
    "X-API-Key": "api-key-value"
  }
}
```

## 互換性

すべての変更は後方互換性を保っており、既存のコードには影響がありません。ヘッダーが設定されていない場合は、従来通りの動作となります。

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:1754363530682729 -->

---

**Open in Web UI**: https://d6ekcqgugsege.cloudfront.net/sessions/1754363530682729