### PR TITLE
feat: add Claude Opus 4.1 model support

### DIFF
--- a/src/common/utils/promptCacheUtils.ts
+++ b/src/common/utils/promptCacheUtils.ts
@@ -17,6 +17,7 @@ export type CacheableField = 'messages' | 'system' | 'tools'
 const MODEL_CACHE_SUPPORT: Record<string, CacheableField[]> = {
   // ベースモデル
   'anthropic.claude-opus-4-20250514-v1:0': ['messages', 'system', 'tools'],
+  'anthropic.claude-opus-4-1-20250805-v1:0': ['messages', 'system', 'tools'],
   'anthropic.claude-sonnet-4-20250514-v1:0': ['messages', 'system', 'tools'],
   'anthropic.claude-3-7-sonnet-20250219-v1:0': ['messages', 'system', 'tools'],
   'anthropic.claude-3-5-haiku-20241022-v1:0': ['messages', 'system', 'tools'],

--- a/src/main/api/bedrock/models.ts
+++ b/src/main/api/bedrock/models.ts
@@ -171,6 +171,17 @@ const MODEL_DEFINITIONS: ModelDefinition[] = [
       crossRegion: ['us-east-1', 'us-east-2', 'us-west-2']
     }
   },
+  // Claude Opus 4.1
+  {
+    baseId: 'claude-opus-4-1-20250805-v1:0',
+    name: 'Claude Opus 4.1',
+    toolUse: true,
+    maxTokensLimit: 8192,
+    supportsThinking: true,
+    availability: {
+      crossRegion: ['us-east-1', 'us-east-2', 'us-west-2']
+    }
+  },
   // Claude Sonnet 4
   {
     baseId: 'claude-sonnet-4-20250514-v1:0',

--- a/src/renderer/src/lib/pricing/modelPricing.test.ts
+++ b/src/renderer/src/lib/pricing/modelPricing.test.ts
@@ -51,6 +51,31 @@ test('should calculate cost for Claude Opus 4', () => {
   expect(actualCost).toBeCloseTo(expectedCost, 6)
 })
 
+test('should calculate cost for Claude Opus 4.1', () => {
+  const modelId = 'anthropic.claude-opus-4-1-20250805-v1:0'
+  const inputTokens = 1000
+  const outputTokens = 500
+  const cacheReadTokens = 200
+  const cacheWriteTokens = 100
+
+  const expectedCost =
+    (inputTokens * 0.015 +
+      outputTokens * 0.075 +
+      cacheReadTokens * 0.0015 +
+      cacheWriteTokens * 0.01875) /
+    1000
+
+  const actualCost = calculateCost(
+    modelId,
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens
+  )
+
+  expect(actualCost).toBeCloseTo(expectedCost, 6)
+})
+
 test('should return 0 for unknown model', () => {
   const modelId = 'unknown-model'
   const cost = calculateCost(modelId, 1000, 500)
@@ -108,6 +133,15 @@ test('should contain Claude Sonnet 4 pricing', () => {
 
 test('should contain Claude Opus 4 pricing', () => {
   expect(modelPricing['opus-4']).toEqual({
+    input: 0.015,
+    output: 0.075,
+    cacheRead: 0.0015,
+    cacheWrite: 0.01875
+  })
+})
+
+test('should contain Claude Opus 4.1 pricing', () => {
+  expect(modelPricing['opus-4-1']).toEqual({
     input: 0.015,
     output: 0.075,
     cacheRead: 0.0015,

--- a/src/renderer/src/lib/pricing/modelPricing.ts
+++ b/src/renderer/src/lib/pricing/modelPricing.ts
@@ -14,6 +14,7 @@ export const modelPricing = {
   // Claude 4 Models
   'sonnet-4': { input: 0.003, output: 0.015, cacheRead: 0.0003, cacheWrite: 0.00375 },
   'opus-4': { input: 0.015, output: 0.075, cacheRead: 0.0015, cacheWrite: 0.01875 },
+  'opus-4-1': { input: 0.015, output: 0.075, cacheRead: 0.0015, cacheWrite: 0.01875 },
 
   // Nova
   'nova-pro': { input: 0.0008, output: 0.0032, cacheRead: 0.0002, cacheWrite: 0 },


### PR DESCRIPTION
- Add Claude Opus 4.1 (claude-opus-4-1-20250805-v1:0) to model definitions
- Configure pricing information for Opus 4.1 (/opt/homebrew/Cellar/zsh/5.9/bin/zsh.015 input, /opt/homebrew/Cellar/zsh/5.9/bin/zsh.075 output per 1K tokens)
- Add prompt cache support for messages, system, and tools
- Add test cases for cost calculation and pricing validation
- Support cross-region deployment (us-east-1, us-east-2, us-west-2)
- Enable thinking mode and tool use capabilities

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
