### PR TITLE
Fix: Update GitHub repository URLs to aws-samples/bedrock-engineer

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.17.0",
   "description": "Autonomous software development agent apps using Amazon Bedrock, capable of customize to create/edit files, execute commands, search the web, use knowledge base, use multi-agents, generative images and more.",
   "main": "./out/main/index.js",
-  "homepage": "https://github.com/daisuke-awaji/bedrock-engineer",
+  "homepage": "https://github.com/aws-samples/bedrock-engineer",
   "engines": {
     "node": ">=18.0.0"
   },

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -224,7 +224,7 @@ function createMenu(window: BrowserWindow) {
         {
           label: 'GitHub Repository',
           click: async () => {
-            await shell.openExternal('https://github.com/daisuke-awaji/bedrock-engineer')
+            await shell.openExternal('https://github.com/aws-samples/bedrock-engineer')
           }
         }
       ]


### PR DESCRIPTION
## Description

This PR fixes incorrect GitHub repository URLs in the application and package.json files.

### Changes
- Updated GitHub repository URL in Help menu from `daisuke-awaji/bedrock-engineer` to `aws-samples/bedrock-engineer`
- Updated homepage URL in package.json from `daisuke-awaji/bedrock-engineer` to `aws-samples/bedrock-engineer`

These changes ensure that users are directed to the correct repository when selecting "GitHub Repository" from the help menu.

## Related Issues
N/A

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:1754443339514729 -->

---

**Open in Web UI**: https://d6ekcqgugsege.cloudfront.net/sessions/1754443339514729