### PR TITLE
fix: use dynamic max tokens limit based on selected model

### DIFF
--- a/src/common/models/models.ts
+++ b/src/common/models/models.ts
@@ -235,7 +235,7 @@ const MODEL_REGISTRY: ModelConfig[] = [
     provider: 'anthropic',
     category: 'text',
     toolUse: true,
-    maxTokensLimit: 32768,
+    maxTokensLimit: 32000,
     supportsThinking: true,
     availability: {
       crossRegion: ['us-east-1', 'us-east-2', 'us-west-2']
@@ -259,7 +259,7 @@ const MODEL_REGISTRY: ModelConfig[] = [
     provider: 'anthropic',
     category: 'text',
     toolUse: true,
-    maxTokensLimit: 8192,
+    maxTokensLimit: 32000,
     supportsThinking: true,
     availability: {
       crossRegion: ['us-east-1', 'us-east-2', 'us-west-2']
@@ -283,7 +283,7 @@ const MODEL_REGISTRY: ModelConfig[] = [
     provider: 'anthropic',
     category: 'text',
     toolUse: true,
-    maxTokensLimit: 8192,
+    maxTokensLimit: 64000,
     supportsThinking: true,
     availability: {
       crossRegion: ['us-east-1', 'us-east-2', 'us-west-2', 'ap-northeast-1', 'ap-northeast-3']

--- a/src/renderer/src/pages/SettingPage/components/sections/AWSSection.tsx
+++ b/src/renderer/src/pages/SettingPage/components/sections/AWSSection.tsx
@@ -352,7 +352,7 @@ export const AWSSection: React.FC<AWSSectionProps> = ({
             placeholder={t('Max tokens')}
             value={inferenceParams.maxTokens}
             min={1}
-            max={4096}
+            max={currentLLM?.maxTokensLimit || 8192}
             onChange={(e) => {
               onUpdateInferenceParams({ maxTokens: parseInt(e.target.value, 10) })
             }}


### PR DESCRIPTION
- Change max attribute from fixed 4096 to model's maxTokensLimit
- Fixes issue where spinner controls reset Claude Sonnet 4 tokens to 4096
- Update model token limits: Claude Sonnet 4 (64k), Opus 4/4.1 (32k)
- Now properly supports models with higher token limits

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
