### PR TITLE
Fix GPT-OSS 120B reasoningContent validation error (#239)

### DIFF
--- a/src/common/models/models.ts
+++ b/src/common/models/models.ts
@@ -434,6 +434,7 @@ const MODEL_REGISTRY: ModelConfig[] = [
     category: 'text',
     toolUse: true,
     maxTokensLimit: 8192,
+    supportsThinking: false,
     availability: {
       base: ['us-west-2']
     }
@@ -447,6 +448,7 @@ const MODEL_REGISTRY: ModelConfig[] = [
     category: 'text',
     toolUse: true,
     maxTokensLimit: 8192,
+    supportsThinking: false,
     availability: {
       base: ['us-west-2']
     }


### PR DESCRIPTION
- Add supportsThinking: false to GPT-OSS models in models.ts
- Filter out reasoningContent for non-thinking models in useAgentChat.ts
- Add conditional processing for reasoningContent during streaming
- Prevents ValidationException when using GPT-OSS models on second turn

