### PR TITLE
feat: Add About dialog with version info to app menu

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, shell, BrowserWindow, Menu, MenuItem } from 'electron'
+import { app, shell, BrowserWindow, Menu, MenuItem, dialog } from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../build/icon.ico?asset'
@@ -121,6 +121,16 @@ async function setupSessionProxy(window: BrowserWindow): Promise<void> {
   }
 }
 
+function showAboutDialog() {
+  dialog.showMessageBox({
+    type: 'info',
+    title: `About ${app.name}`,
+    message: app.name,
+    detail: `Version: ${app.getVersion()}\n\nElectron: ${process.versions.electron}\nChrome: ${process.versions.chrome}\nNode.js: ${process.versions.node}`,
+    buttons: ['OK']
+  })
+}
+
 function createMenu(window: BrowserWindow) {
   const isMac = process.platform === 'darwin'
   const template = [
@@ -130,7 +140,10 @@ function createMenu(window: BrowserWindow) {
           {
             label: app.name,
             submenu: [
-              { role: 'about' },
+              {
+                label: `About ${app.name}`,
+                click: showAboutDialog
+              },
               { type: 'separator' },
               { role: 'services' },
               { type: 'separator' },
@@ -221,6 +234,11 @@ function createMenu(window: BrowserWindow) {
     {
       role: 'help',
       submenu: [
+        {
+          label: `About ${app.name}`,
+          click: showAboutDialog
+        },
+        { type: 'separator' },
         {
           label: 'GitHub Repository',
           click: async () => {


### PR DESCRIPTION
- Implement custom About dialog showing app version, Electron, Chrome, and Node.js versions
- Add About menu item to macOS application menu (replacing default about)
- Add About menu item to Help menu for all platforms (macOS, Windows, Linux)
- Provides unified version information display across all platforms

## Mac
<img width="464" height="183" alt="スクリーンショット 2025-10-09 16 44 51" src="https://github.com/user-attachments/assets/b0334dac-c335-44a9-9cf8-f8c3a9a3d210" />
<img width="332" height="316" alt="image" src="https://github.com/user-attachments/assets/6147d9e6-f9b2-4bdd-8077-9d8c19613e2d" />


## Windows
<img width="455" height="236" alt="スクリーンショット 2025-10-09 16 43 36" src="https://github.com/user-attachments/assets/2b0c0166-7063-4801-a5b4-d3c10bf2c6fd" />


<img width="491" height="303" alt="スクリーンショット 2025-10-09 16 43 29" src="https://github.com/user-attachments/assets/d80dd757-eb82-409a-b8a5-4be40453f8e6" />
