### PR TITLE
fix(CodeRenderer): improve image URL detection logic

### DIFF
--- a/src/renderer/src/pages/ChatPage/components/Code/CodeRenderer.tsx
+++ b/src/renderer/src/pages/ChatPage/components/Code/CodeRenderer.tsx
@@ -52,10 +52,24 @@ export const CodeRenderer: React.FC<CodeRendererProps> = ({ text = '', className
         />
       ),
       img: ({ src, alt, ...props }: ImgProps) => {
-        if (src?.startsWith('/')) {
-          return <LocalImage src={src} alt={alt || ''} {...props} />
+        // Check if it's a remote URL (has a valid protocol)
+        const isRemoteUrl = (() => {
+          if (!src) return false
+          try {
+            const url = new URL(src)
+            return ['http:', 'https:', 'data:', 'blob:'].includes(url.protocol)
+          } catch {
+            // If URL parsing fails, it's likely a local path
+            return false
+          }
+        })()
+
+        if (isRemoteUrl) {
+          return <img src={src} alt={alt} {...props} />
         }
-        return <img src={src} alt={alt} {...props} />
+
+        // Treat everything else as local path
+        return <LocalImage src={src || ''} alt={alt || ''} {...props} />
       },
       code: ({ inline, className, children, ...props }: CodeProps) => {
         const match = /language-(\w+)/.exec(className || '')


### PR DESCRIPTION
Enhance the image rendering logic to properly distinguish between remote and local images using URL parsing instead of path prefix checking.

Changes:
- Replace simple path prefix check with robust URL validation
- Add protocol-based detection for remote URLs (http, https, data, blob)
- Use try-catch with URL constructor to safely parse URLs
- Invert logic: remote URLs use standard img tag, local paths use LocalImage
- Add fallback to treat unparseable URLs as local paths

This prevents false positives when determining image types and ensures proper handling of various URL formats including data URIs and blob URLs.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
