### PR TITLE
fix: prioritize text data over images when pasting into chat input

### DIFF
--- a/src/renderer/src/pages/ChatPage/components/InputForm/TextArea.tsx
+++ b/src/renderer/src/pages/ChatPage/components/InputForm/TextArea.tsx
@@ -172,9 +172,23 @@ export const TextArea: React.FC<TextAreaProps> = ({
       const items = e.clipboardData?.items
       if (!items) return
 
+      // Check for text data (prioritize text over images)
+      const hasTextData = Array.from(items).some(
+        (item) => item.type === 'text/plain' || item.type === 'text/html'
+      )
+
+      // If text data exists, allow default paste behavior (paste as text)
+      if (hasTextData) {
+        return
+      }
+
+      // Only process as images if no text data exists
       const imageItems = Array.from(items).filter((item) => item.type.indexOf('image') !== -1)
 
       if (imageItems.length === 0) return
+
+      // Prevent default paste behavior when handling as images
+      e.preventDefault()
 
       if (attachedImages.length + imageItems.length > 20) {
         toast.error(t('textarea.imageValidation.tooManyImages'))


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Fixed an issue where copied text was occasionally pasted as an image in the chat input field. The paste handler now checks for text data (text/plain or text/html) first and only processes clipboard content as images when no text data is present. This ensures text is always pasted as text, preventing unintended image attachments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
