### PR TITLE
Fix: Add auto-scroll to textarea on newline input

### DIFF
--- a/src/renderer/src/pages/ChatPage/components/InputForm/TextArea.tsx
+++ b/src/renderer/src/pages/ChatPage/components/InputForm/TextArea.tsx
@@ -133,6 +133,13 @@ export const TextArea: React.FC<TextAreaProps> = ({
     }
   }, [value, isManuallyResized, onHeightChange])
 
+  // Automatically scroll to the bottom when the value changes (to follow new lines)
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.scrollTop = textareaRef.current.scrollHeight
+    }
+  }, [value])
+
   // No scroll position monitoring needed as we're keeping the border visible at all times
 
   const validateAndProcessImage = useCallback(


### PR DESCRIPTION
**Issue #, if available:**

N/A

**Description of changes:**

Added auto-scroll functionality to the textarea to follow cursor position on newline input. The latest input position now remains visible even when entering long text over 10 lines.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.