### PR TITLE
Add Claude Opus 4.5

### DIFF
--- a/src/common/models/models.ts
+++ b/src/common/models/models.ts
@@ -638,6 +638,35 @@ const MODEL_REGISTRY: ModelConfig[] = [
     }
   },
 
+  // Claude Opus 4.5
+  {
+    baseId: 'claude-opus-4-5-20251101-v1:0',
+    name: 'Claude Opus 4.5',
+    provider: 'anthropic',
+    category: 'text',
+    toolUse: true,
+    maxTokensLimit: 8192,
+    supportsThinking: true,
+    inferenceProfiles: [
+      {
+        type: 'global',
+        prefix: 'global',
+        regions: ['us-west-2', 'us-east-1', 'us-east-2', 'eu-west-1', 'ap-northeast-1'],
+        displaySuffix: '(Global)'
+      }
+    ],
+    pricing: {
+      input: 0.005,
+      output: 0.025,
+      cacheRead: 0.0005,
+      cacheWrite: 0.00625
+    },
+    cache: {
+      supported: true,
+      cacheableFields: ['messages', 'system', 'tools']
+    }
+  },
+
   // Amazon Nova Premier
   {
     baseId: 'nova-premier-v1:0',


### PR DESCRIPTION
Add support for Claude Opus 4.5 (claude-opus-4-5-20251101-v1:0) from Anthropic.

Key features:
- Extended thinking capabilities with supportsThinking flag
- Tool use support enabled
- 8192 max tokens limit
- Global inference profiles across 5 regions (us-west-2, us-east-1, us-east-2, eu-west-1, ap-northeast-1)
- Prompt caching support for messages, system, and tools
- Pricing configured for input ($0.005), output ($0.025), and cache operations

This addition enables users to leverage the latest Claude Opus model with enhanced reasoning capabilities.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
