### PR TITLE
Amazon Nova 2 models

### DIFF
--- a/src/common/models/models.ts
+++ b/src/common/models/models.ts
@@ -777,6 +777,30 @@ const MODEL_REGISTRY: ModelConfig[] = [
     }
   },
 
+  // Amazon Nova 2 Lite
+  {
+    baseId: 'nova-2-lite-v1:0',
+    name: 'Amazon Nova 2 Lite',
+    provider: 'amazon',
+    category: 'text',
+    toolUse: true,
+    maxTokensLimit: 5120,
+    inferenceProfiles: [
+      {
+        type: 'regional-us',
+        prefix: 'us',
+        regions: ['us-east-1', 'us-west-2'],
+        displaySuffix: '(US)'
+      },
+      {
+        type: 'global',
+        prefix: 'global',
+        regions: ['us-east-1', 'us-west-2'],
+        displaySuffix: '(Global)'
+      }
+    ]
+  },
+
   // Amazon Nova Micro
   {
     baseId: 'nova-micro-v1:0',

--- a/src/main/api/sonic/client.ts
+++ b/src/main/api/sonic/client.ts
@@ -598,7 +598,7 @@ export class NovaSonicBidirectionalStreamClient {
 
       const response = await this.bedrockRuntimeClient.send(
         new InvokeModelWithBidirectionalStreamCommand({
-          modelId: 'amazon.nova-sonic-v1:0',
+          modelId: 'amazon.nova-2-sonic-v1:0',
           body: asyncIterable
         })
       )

--- a/src/main/api/sonic/constants.ts
+++ b/src/main/api/sonic/constants.ts
@@ -1,9 +1,7 @@
-// Nova Sonic supported regions as of 2024
+// Nova 2 Sonic supported regions
 export const NOVA_SONIC_SUPPORTED_REGIONS = [
   'us-east-1', // 米国東部 (バージニア北部)
-  'us-west-2', // 米国西部 (オレゴン)
-  'ap-northeast-1', // アジアパシフィック (東京)
-  'eu-north-1' // 欧州 (ストックホルム)
+  'us-west-2' // 米国西部 (オレゴン)
 ] as const
 
 export type NovaSonicSupportedRegion = (typeof NOVA_SONIC_SUPPORTED_REGIONS)[number]


### PR DESCRIPTION
- Add Amazon Nova 2 Lite model configuration with regional and global inference profiles
- Update Nova Sonic model ID to nova-2-sonic-v1:0
- Reduce Nova Sonic supported regions to US-only (us-east-1, us-west-2)

This update adds the new Nova 2 Lite text model and migrates from Nova Sonic to Nova 2 Sonic, reflecting the updated model versions and their current regional availability.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
