### PR TITLE
security: consolidate vulnerability fixes (axios, vite, hono, dompurify, fast-xml-parser)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@monaco-editor/react": "^4.6.0",
         "@reactour/tour": "3.7.0",
         "@tshepomgaga/aws-sfn-graph": "0.0.6",
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "chart.js": "^4.4.8",
         "cors": "2.8.5",
         "diff": "8.0.3",
@@ -97,7 +97,7 @@
         "tailwindcss": "3.4.10",
         "ts-jest": "29.2.4",
         "typescript": "5.5.2",
-        "vite": "^6.4.1"
+        "vite": "^6.4.2"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -3796,9 +3796,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.10",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.10.tgz",
-      "integrity": "sha512-hZ7nOssGqRgyV3FVVQdfi+U4q02uB23bpnYpdvNXkYTRRyWx84b7yf1ans+dnJ/7h41sGL3CeQTfO+ZGxuO+Iw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -8878,14 +8878,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -11441,9 +11441,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -12954,21 +12954,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
-      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -12977,8 +12965,24 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.0.0",
-        "strnum": "^2.1.2"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+      "integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -14103,9 +14107,9 @@
       "license": "CC0-1.0"
     },
     "node_modules/hono": {
-      "version": "4.12.7",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
-      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -18527,6 +18531,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -19282,10 +19301,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.3",
@@ -22471,9 +22493,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@monaco-editor/react": "^4.6.0",
     "@reactour/tour": "3.7.0",
     "@tshepomgaga/aws-sfn-graph": "0.0.6",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "chart.js": "^4.4.8",
     "cors": "2.8.5",
     "diff": "8.0.3",
@@ -118,12 +118,15 @@
     "tailwindcss": "3.4.10",
     "ts-jest": "29.2.4",
     "typescript": "5.5.2",
-    "vite": "^6.4.1"
+    "vite": "^6.4.2"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.24.0",
     "@rollup/rollup-win32-x64-msvc": "4.20.0",
     "dmg-license": "1.0.11"
+  },
+  "overrides": {
+    "fast-xml-parser": "5.5.8"
   },
   "jest": {
     "preset": "ts-jest",


### PR DESCRIPTION
## Summary

Consolidates six security-related Dependabot PRs into a single PR for faster review and merge.

This PR **supersedes** the following PRs:

| # | Package | Version | Vulnerability |
|---|---------|---------|---------------|
| #334 | `axios` | 1.13.5 → 1.15.0 | SSRF via `no_proxy` bypass (#10661), cloud metadata exfiltration via header injection (#10660) |
| #330 | `vite` | 6.4.1 → 6.4.2 | Path traversal in optimize-deps sourcemap handler, `server.fs` bypass via env transport |
| #337 | `hono` | 4.12.7 → 4.12.14 | [GHSA-458j-xx4x-4375](https://github.com/advisories/GHSA-458j-xx4x-4375) Improper JSX attribute name handling in SSR |
| #331 | `@hono/node-server` | 1.19.10 → 1.19.14 | [GHSA-92pp-h63x-v22m](https://github.com/advisories/GHSA-92pp-h63x-v22m) Serve Static middleware bypass via repeated slashes |
| #338 | `dompurify` | 3.3.3 → 3.4.0 | Prototype pollution via `CUSTOM_ELEMENT_HANDLING`, `ADD_ATTR`/`FORBID_TAGS` bypasses |
| #333 | `fast-xml-parser` | 5.4.1 → 5.5.8 | Entity expansion limits (DoS mitigation) |

## Changes

- `package.json`
  - `axios`: `^1.13.5` → `^1.15.0` (direct dep)
  - `vite`: `^6.4.1` → `^6.4.2` (direct devDep)
  - Added `overrides.fast-xml-parser: 5.5.8` — required because the vulnerable version is pinned transitively by `@aws-sdk/xml-builder`
- `package-lock.json` regenerated via `npm install` + `npm update hono @hono/node-server dompurify fast-xml-parser`

Transitive dependencies `hono`, `@hono/node-server`, and `dompurify` are upgraded in-range via the lockfile refresh.

## Verification performed locally

| Check | Result |
|---|---|
| Resolved versions (`npm ls`) | ✅ `axios@1.15.0`, `vite@6.4.2`, `hono@4.12.14`, `@hono/node-server@1.19.14`, `dompurify@3.4.0`, `fast-xml-parser@5.5.8 (overridden)` |
| `npm run typecheck` (node + web) | ✅ Pass |
| `npm run build` (`electron-vite build` main/preload/renderer) | ✅ Pass |
| `npm test` (Jest) | ✅ 262 passed, 2 skipped, 0 failed |
| `npm run lint` | ✅ 0 errors (only pre-existing prettier warnings) |
| `npm audit --audit-level=high` | ✅ All six targeted advisories resolved. Remaining `lodash-es` advisories via `chevrotain`/`langium` are out of scope for this PR. |

## Notes for reviewers

- Once this PR is merged, Dependabot PRs #330, #331, #333, #334, #337, and #338 can be closed.
- `#328` (electron 41.0.0 → 41.1.1), `#329` (lodash 4.17.23 → 4.18.1), and `#336` (follow-redirects 1.15.11 → 1.16.0) were intentionally excluded as they contain no explicit security advisories in their release notes.
